### PR TITLE
fix dependencies order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ set(SOURCE_FILES
 	src/volume.hpp
 	src/io_util.cpp)
 
-set(THIRDPARTY_LIBRARIES ${ZLIB_LIBRARIES} ${Boost_LIBRARIES})
+set(THIRDPARTY_LIBRARIES ${Boost_LIBRARIES} ${ZLIB_LIBRARIES} )
 
 add_executable(gttool ${SOURCE_FILES})
 target_link_libraries(gttool ${THIRDPARTY_LIBRARIES})


### PR DESCRIPTION
If library A depends on library B, then A must come before B on the command line.